### PR TITLE
Add support for timelog UpdatedDate property

### DIFF
--- a/Taviloglu.Wrike.ApiClient.Tests.Integration/Timelogs/TimelogsTests.cs
+++ b/Taviloglu.Wrike.ApiClient.Tests.Integration/Timelogs/TimelogsTests.cs
@@ -31,7 +31,21 @@ namespace Taviloglu.Wrike.ApiClient.Tests.Integration.Timelogs
             var timelogs = WrikeClientFactory.GetWrikeClient().Timelogs.GetAsync().Result;
             Assert.IsNotNull(timelogs);
             Assert.GreaterOrEqual(timelogs.Count, 1);
-        }   
+        }
+
+        [Test]
+        public void GetAsync_WithUpdatedDateFilter_ShouldReturnTimelogs()
+        {
+            var updatedDateFilter = new Core.WrikeDateFilterRange(new DateTime(2000, 1, 1), DateTime.UtcNow);
+            var timelogs = WrikeClientFactory.GetWrikeClient().Timelogs.GetAsync(updatedDate: updatedDateFilter).Result;
+
+            Assert.IsNotNull(timelogs);
+            Assert.NotZero(timelogs.Count);
+            foreach (var timelog in timelogs)
+            {
+                Assert.IsTrue(updatedDateFilter.Start <= timelog.UpdatedDate && timelog.UpdatedDate < updatedDateFilter.End);
+            }
+        }
 
         // TODO: test other get options fiwth taskId, contactId, folderId, timelogCategoryId
 
@@ -86,5 +100,6 @@ namespace Taviloglu.Wrike.ApiClient.Tests.Integration.Timelogs
 
             Assert.IsTrue(isTimelogDeleted);
         }
+
     }
 }

--- a/Taviloglu.Wrike.ApiClient/FoldersAndProjects/IWrikeFoldersAndProjectsClient.cs
+++ b/Taviloglu.Wrike.ApiClient/FoldersAndProjects/IWrikeFoldersAndProjectsClient.cs
@@ -9,7 +9,7 @@ using Taviloglu.Wrike.Core.FoldersAndProjects;
 namespace Taviloglu.Wrike.ApiClient
 {
     /// <summary>
-    /// Folder & Project operations
+    /// Folder &amp; Project operations
     /// </summary>
     public interface IWrikeFoldersAndProjectsClient
     {
@@ -34,7 +34,7 @@ namespace Taviloglu.Wrike.ApiClient
         /// <param name="updatedDate">Updated date filter, range</param>
         /// <param name="isProject">Get only projects (true) / only folders (false)</param>
         /// <param name="isDeleted">Get folders from Root (false) / Recycle Bin (true)</param>
-        /// <param name="fields">optional fields to be included in the response model. Use <see cref="WrikeFolderTree.OptionalFields"/></param> 
+        /// <param name="optionalFields">optional fields to be included in the response model. Use <see cref="WrikeFolderTree.OptionalFields"/></param> 
         /// See <see href="https://developers.wrike.com/documentation/api/methods/get-folder-tree"/>
         Task<List<WrikeFolderTree>> GetFolderTreeAsync(
             string folderId = null,

--- a/Taviloglu.Wrike.ApiClient/Timelogs/IWrikeTimelogsClient.cs
+++ b/Taviloglu.Wrike.ApiClient/Timelogs/IWrikeTimelogsClient.cs
@@ -49,6 +49,7 @@ namespace Taviloglu.Wrike.ApiClient
         /// <param name="taskId">Get all timelog records for a task.</param>
         /// <param name="categoryId"> Get all timelog records with specific timelog category.</param>
         /// <param name="createdDate">Created date filter, exact match or range</param>
+        /// <param name="updatedDate">Updated date filter, exact match or range</param>
         /// <param name="trackedDate">Tracked date filter, exact match or range</param>
         /// <param name="me">If present - only timelogs created by current user are returned</param>
         /// <param name="descendants">Adds all descendant tasks to search scope</param>
@@ -62,6 +63,7 @@ namespace Taviloglu.Wrike.ApiClient
             string taskId = null,
             string categoryId = null,
             WrikeDateFilterRange createdDate = null,
+            WrikeDateFilterRange updatedDate = null,
             IWrikeDateFilter trackedDate = null,
             bool? me = null,
             bool? descendants = null,

--- a/Taviloglu.Wrike.ApiClient/Timelogs/WrikeClient.Timelogs.cs
+++ b/Taviloglu.Wrike.ApiClient/Timelogs/WrikeClient.Timelogs.cs
@@ -56,7 +56,7 @@ namespace Taviloglu.Wrike.ApiClient
             var response = await SendRequest<WrikeTimelog>($"timelogs/{id}", HttpMethods.Delete).ConfigureAwait(false);
         }
 
-        async Task<List<WrikeTimelog>> IWrikeTimelogsClient.GetAsync(string contactId, string folderId, string taskId, string categoryId, WrikeDateFilterRange createdDate, IWrikeDateFilter trackedDate, bool? me, bool? descendants, bool? subTasks, bool? plainText, List<string> categoryIds)
+        async Task<List<WrikeTimelog>> IWrikeTimelogsClient.GetAsync(string contactId, string folderId, string taskId, string categoryId, WrikeDateFilterRange createdDate, WrikeDateFilterRange updatedDate, IWrikeDateFilter trackedDate, bool? me, bool? descendants, bool? subTasks, bool? plainText, List<string> categoryIds)
         {
 
             int notNullCount = 0;
@@ -88,6 +88,7 @@ namespace Taviloglu.Wrike.ApiClient
 
             var uriBuilder = new WrikeUriBuilder(requestUri)
             .AddParameter("createdDate", createdDate, new CustomDateTimeConverter("yyyy-MM-dd'T'HH:mm:ss'Z'"))
+            .AddParameter("updatedDate", updatedDate, new CustomDateTimeConverter("yyyy-MM-dd'T'HH:mm:ss'Z'"))
             .AddParameter("trackedDate", trackedDate, new CustomDateTimeConverter("yyyy-MM-dd'T'HH:mm:ss"))
             .AddParameter("me", me)
             .AddParameter("descendants", descendants)

--- a/Taviloglu.Wrike.Core/Timelogs/WrikeTimelog.cs
+++ b/Taviloglu.Wrike.Core/Timelogs/WrikeTimelog.cs
@@ -65,6 +65,13 @@ namespace Taviloglu.Wrike.Core.Timelogs
         public DateTime CreatedDate { get; set; }
 
         /// <summary>
+        /// Date on which timelog was updated Format: yyyy-MM-dd'T'HH:mm:ss'Z'
+        /// </summary>
+        [JsonProperty("updatedDate")]
+        [JsonConverter(typeof(CustomDateTimeConverter), new object[] { "yyyy-MM-dd'T'HH:mm:ss'Z'" })]
+        public DateTime UpdatedDate { get; set; }
+
+        /// <summary>
         /// Date for which timelog was recorded Format: yyyy-MM-dd
         /// </summary>
         [JsonProperty("trackedDate")]


### PR DESCRIPTION
This PR does the following:

- Adds WrikeTimelog.UpdatedDate property
- Adds support for querying by updatedDate via IWrikeTimelogsClient.GetAsync()
- Adds a passing integration test using these features.
