### PR TITLE
Fixes issue #14 - Add Custom to the WrikeProjectStatus enumeration

### DIFF
--- a/Taviloglu.Wrike.Core/FoldersAndProjects/WrikeProjectStatus.cs
+++ b/Taviloglu.Wrike.Core/FoldersAndProjects/WrikeProjectStatus.cs
@@ -2,6 +2,6 @@
 {
     public enum WrikeProjectStatus
     {
-        Green, Yellow, Red, Completed, OnHold, Cancelled
+        Green, Yellow, Red, Completed, OnHold, Cancelled, Custom
     }
 }


### PR DESCRIPTION
This updates the WrikeProjectStatus enumeration to match the documentation for Wrike API v4 by adding "Custom" to the end of the list. This prevents an exception when parsing the JSON for a set of folders which includes a project with a custom status.