### PR TITLE
Fix "me" field

### DIFF
--- a/Taviloglu.Wrike.ApiClient/Contacts/WrikeClient.Contacts.cs
+++ b/Taviloglu.Wrike.ApiClient/Contacts/WrikeClient.Contacts.cs
@@ -14,9 +14,12 @@ namespace Taviloglu.Wrike.ApiClient
             var requestUri = "contacts";
 
             var uriBuilder = new WrikeUriBuilder(requestUri)
-                .AddParameter("me", me)
                 .AddParameter("metadata", metadata)
                 .AddParameter("deleted", isDeleted);
+                
+            if (me == true) {
+                uriBuilder.AddParameter("me", me);
+            }
 
             if (retrieveMetadata.HasValue && retrieveMetadata == true)
             {


### PR DESCRIPTION
The field "me" is not handled as a true boolean. Wrike simply looks for its presence, whether it actually true or false doesn't matter. Including "me" on every request makes it impossible to pull all contacts.

See: https://developers.wrike.com/documentation/api/methods/query-contacts

me
optional boolean	If present - only contact info of requesting user is returned