### PR TITLE
Fixes issue #19 - Add "Multiple" to the custom field type enumeration

### DIFF
--- a/Taviloglu.Wrike.Core/CustomFields/WrikeCustomFieldType.cs
+++ b/Taviloglu.Wrike.Core/CustomFields/WrikeCustomFieldType.cs
@@ -10,6 +10,7 @@
         Date,
         Duration,
         Checkbox,
-        Contacts
+        Contacts,
+        Multiple
     }
 }


### PR DESCRIPTION
Update WrikeCustomFieldTypes.cs to add "Multiple" which is a type available in the Wrike API.