### PR TITLE
feat(colors): adds "DarkRed" enum value

### DIFF
--- a/Taviloglu.Wrike.Core/Colors/WrikeColor.cs
+++ b/Taviloglu.Wrike.Core/Colors/WrikeColor.cs
@@ -47,7 +47,7 @@ namespace Taviloglu.Wrike.Core.Colors
         /// </summary>
         public enum CustomStatusColor
         {
-            Brown, Red, Purple, Indigo, DarkBlue, Blue, Turquoise, DarkCyan, Green, YellowGreen, Yellow, Orange, Gray,
+            Brown, Red, Purple, Indigo, DarkBlue, Blue, Turquoise, DarkCyan, Green, YellowGreen, Yellow, Orange, Gray, DarkRed,
         }
     }
 


### PR DESCRIPTION
Adds the value `DarkRed` to the `CustomStatusColor` Type. This fixes issue #39 . This should be monitored closely as it's possible that Workflows move to custom colors in the future.