### PR TITLE
#44 Support CustomItemTypeId on WrikeTask response as optional field

### DIFF
--- a/Taviloglu.Wrike.ApiClient.Tests.Unit/Tasks/TasksTests.cs
+++ b/Taviloglu.Wrike.ApiClient.Tests.Unit/Tasks/TasksTests.cs
@@ -31,7 +31,7 @@ namespace Taviloglu.Wrike.ApiClient.Tests.Unit.Tasks
 
             var ex = Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => TestConstants.WrikeClient.Tasks.GetAsync(new List<string> { "taskId1","taskId2"}, notSupportedOptionalFields));
             Assert.AreEqual("optionalFields", ex.ParamName);
-            Assert.IsTrue(ex.Message.Contains("Only Recurrent, AttachmentCount and EffortAllocation is supported."));
+            Assert.IsTrue(ex.Message.Contains("Only Recurrent, AttachmentCount, EffortAllocation, CustomItemTypeId is supported."));
         }
 
         [Test]
@@ -41,7 +41,7 @@ namespace Taviloglu.Wrike.ApiClient.Tests.Unit.Tasks
 
             var ex = Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => TestConstants.WrikeClient.Tasks.GetAsync(new List<string> { "taskId1", "taskId2" }, notSupportedOptionalFields));
             Assert.AreEqual("optionalFields", ex.ParamName);
-            Assert.IsTrue(ex.Message.Contains("Only Recurrent, AttachmentCount and EffortAllocation is supported."));
+            Assert.IsTrue(ex.Message.Contains("Only Recurrent, AttachmentCount, EffortAllocation, CustomItemTypeId is supported."));
         }
     }
 }

--- a/Taviloglu.Wrike.ApiClient/Tasks/WrikeClient.Tasks.cs
+++ b/Taviloglu.Wrike.ApiClient/Tasks/WrikeClient.Tasks.cs
@@ -119,14 +119,15 @@ namespace Taviloglu.Wrike.ApiClient
             var supportedOptionalFields = new List<string> { 
                 WrikeTask.OptionalFields.Recurrent, 
                 WrikeTask.OptionalFields.AttachmentCount,
-                WrikeTask.OptionalFields.EffortAllocation
+                WrikeTask.OptionalFields.EffortAllocation,
+                WrikeTask.OptionalFields.CustomItemTypeId
             };
 
             if (optionalFields != null &&
-                (optionalFields.Count > 3 ||
+                (optionalFields.Count > 4 ||
                 optionalFields.Any(o => !supportedOptionalFields.Contains(o))))
             {
-                throw new ArgumentOutOfRangeException(nameof(optionalFields),"Only Recurrent, AttachmentCount and EffortAllocation is supported.");
+                throw new ArgumentOutOfRangeException(nameof(optionalFields),"Only Recurrent, AttachmentCount, EffortAllocation, CustomItemTypeId is supported.");
             }
 
             var uriBuilder = new WrikeUriBuilder($"tasks/{taskIds}")

--- a/Taviloglu.Wrike.Core/Tasks/WrikeTask.cs
+++ b/Taviloglu.Wrike.Core/Tasks/WrikeTask.cs
@@ -46,7 +46,8 @@ namespace Taviloglu.Wrike.Core.Tasks
             List<WrikeMetadata> metadata = null,
             List<WrikeCustomFieldData> customFields = null,
             string customStatus = null,
-            WrikeTaskEffortAllocation effortAllocation = null)
+            WrikeTaskEffortAllocation effortAllocation = null,
+            string customItemTypeId = null)
         {
             title.ValidateParameter(nameof(title));
 
@@ -65,6 +66,7 @@ namespace Taviloglu.Wrike.Core.Tasks
             CustomFields = customFields;
             CustomStatusId = customStatus;
             EffortAllocation = effortAllocation;
+            CustomItemTypeId = customItemTypeId;
         }
 
         /// <summary>
@@ -166,7 +168,7 @@ namespace Taviloglu.Wrike.Core.Tasks
         /// </summary>
         [JsonProperty("authorIds")]
         public List<string> AuthorIds { get; set; }
-        
+
         /// <summary>
         /// Custom status ID
         /// </summary>
@@ -252,11 +254,17 @@ namespace Taviloglu.Wrike.Core.Tasks
         public WrikeTaskEffortAllocation EffortAllocation { get; set; }
 
         /// <summary>
+        /// Custom Item Type ID
+        /// </summary>
+        [JsonProperty("customItemTypeId")]
+        public string CustomItemTypeId { get; set; }
+
+        /// <summary>
         /// Optional fields to be included in the response model 
         /// </summary>
         public class OptionalFields
         {
-            public static List<string> List = new List<string> { AuthorIds, HasAttachments, AttachmentCount , ParentIds , SuperParentIds , SharedIds , ResponsibleIds, Description, BriefDescription, Recurrent, SuperTaskIds, SubTaskIds, DependencyIds, Metadata };
+            public static List<string> List = new List<string> { AuthorIds, HasAttachments, AttachmentCount, ParentIds, SuperParentIds, SharedIds, ResponsibleIds, Description, BriefDescription, Recurrent, SuperTaskIds, SubTaskIds, DependencyIds, Metadata };
             /// <summary>
             /// Author IDs
             /// </summary>
@@ -321,6 +329,10 @@ namespace Taviloglu.Wrike.Core.Tasks
             /// Effort allocation
             /// </summary>
             public const string EffortAllocation = "effortAllocation";
+            /// <summary>
+            /// Custom Item Type ID
+            /// </summary>
+            public const string CustomItemTypeId = "customItemTypeId";
         }
     }
 }


### PR DESCRIPTION
Added support for customItemTypeId as optional field for task api requests. Parsed response accordingly to set the property on WrikeTask instance