### PR TITLE
Add property 'permalink' to WrikeFolderTree

### DIFF
--- a/Taviloglu.Wrike.Core/FoldersAndProjects/WrikeFolderTree.cs
+++ b/Taviloglu.Wrike.Core/FoldersAndProjects/WrikeFolderTree.cs
@@ -41,6 +41,12 @@ namespace Taviloglu.Wrike.Core.FoldersAndProjects
         public WrikeProject Project { get; set; }
 
         /// <summary>
+        /// Folder permalink, exact match
+        /// </summary>
+        [JsonProperty("permalink")]
+        public string Permalink { get; set; }
+
+        /// <summary>
         /// Optional fields to be included in the response model 
         /// </summary>
         public class OptionalFields


### PR DESCRIPTION
This change implements the property 'permalink' into WrikeFolderTree to align with the latest Wrike-API results.