### PR TITLE
Added new CustomField types to WrikeCustomFieldType enum

### DIFF
--- a/Taviloglu.Wrike.Core/CustomFields/WrikeCustomFieldType.cs
+++ b/Taviloglu.Wrike.Core/CustomFields/WrikeCustomFieldType.cs
@@ -11,6 +11,10 @@
         Duration,
         Checkbox,
         Contacts,
-        Multiple
+        Multiple,
+        LinkToDatabase,
+        CalculatedNumeric,
+        CalculatedDate
+        
     }
 }


### PR DESCRIPTION
Added missing CustomField types LinkToDatabase, CalculatedNumeric, CalculatedDate, according to https://developers.wrike.com/api/v4/custom-fields/